### PR TITLE
Update to node 20 and fleek-cli 0.1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:16-alpine
+FROM node:20-lts
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:$PATH"
 
 USER node
-RUN npm install -g @fleekhq/fleek-cli@^0.1.0
+RUN npm install -g @fleekhq/fleek-cli@^0.1.8
 
 COPY entrypoint.sh /home/node/entrypoint.sh
 


### PR DESCRIPTION
Encountering `Cannot find module 'node:crypto'` during build and updating the Dockerfile with node v20 fixed the build issue in one of our projects

Seems github is slowly abandoning node 16
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/